### PR TITLE
Updated debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,14 @@ Source: mintdrivers
 Section: admin
 Priority: optional
 Maintainer: Clement Lefebvre <root@linuxmint.com>
-Build-Depends: debhelper (>= 9), python
+Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
 
 Package: mintdrivers
 Architecture: all
-Depends:
- ${python:Depends}, ${misc:Depends},
- python (>= 2.4), python (<< 3), python-gtk2, python-glade2,
- ubuntu-drivers-common
+Depends: python3 (>= 3.3),
+         python3-gi,
+         ubuntu-drivers-common,
+         ${misc:Depends},
 Description: Driver Manager
  Manage the drivers for your devices.

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,4 @@
 #!/usr/bin/make -f
 
 %:
-	dh ${@} --with python2
-
+	dh ${@}


### PR DESCRIPTION
Out of date, still listed python2 and pygtk instead of python3 and python3-gi

Also removed dh_python from build process