### PR TITLE
Depend on packages python3-aptdaemon, python3-aptdaemon.gtk3widgets

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,8 @@ Package: mintdrivers
 Architecture: all
 Depends: python3 (>= 3.3),
          python3-gi,
+         python3-aptdaemon,
+         python3-aptdaemon.gtk3widgets,
          ubuntu-drivers-common,
          ${misc:Depends},
 Description: Driver Manager


### PR DESCRIPTION
Tested in an ubuntu:14.04 docker with Mint repos added.

Fixed #20, #25.