### PR TITLE
For installed drivers show installed version

### DIFF
--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -392,7 +392,7 @@ class Application():
                 pkg = self.apt_cache[pkg_driver_name]
                 installed = pkg.is_installed
                 description_line1 = "<b>%s</b>" % pkg.shortname
-                description_line2 = "<small>%s</small> %s" % (_("Version"), pkg.candidate.version)
+                description_line2 = "<small>%s</small> %s" % (_("Version"), pkg.candidate.version if not pkg.is_installed else pkg.installed.version)
                 description_line3 = "<small>%s</small>" % pkg.candidate.summary
                 if driver_status == 'recommended':
                     description_line1 = "%s <b><small><span foreground='#58822B'>(%s)</span></small></b>" % (description_line1, _("recommended"))


### PR DESCRIPTION
Currently for all drivers always the candidate version is shown. This confuses users into thinking that installed drivers have already been updated, even if they didn't apply the update in Update Manager yet, and may lead them to never apply said update because they believe Driver Manager is handling it.

This patch shows the installed version of an installed driver.

Fixes #45