### PR TITLE
Fix nvidia driver installation/removal/switching

### DIFF
--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -68,8 +68,8 @@ class Application():
 
         self.info_bar.set_no_show_all(True)
 
-        self.progress_bar = Gtk.ProgressBar()
-        self.box_driver_action.pack_end(self.progress_bar, False, False, 0)
+        self.progress_bar = Gtk.ProgressBar(valign=Gtk.Align.CENTER)
+        self.box_driver_action.pack_end(self.progress_bar, True, True, 0)
         self.progress_bar.set_visible(False)
 
         self.needs_restart = False


### PR DESCRIPTION
- Removing an nvidia driver would fail to actually disable it.  It
  would only remove the main nvidia-driver-xxx package.  This would
  end up breaking mintdrivers as well (it would think the driver was
  manually installed after this).
- Attempting to switch drivers would fail due to a dependency issue
  (really some sort of bug in aptdaemon?).  Even if all old packages
  were removed, residual configuration would cause failure. Purging
  is necessary, but remove_obsolete_dependencies() only removes these
  (even if you're directing it to purge the implicitly selected
  packages).

This breaks up the package handling into separate removal and install
phases.  This is invisible to the user.

- When nvidia packages are being removed, all version-specific files
  are purged.
- nvidia-settings is removed if the net outcome will have no nvidia
  drivers.
- nvidia-prime and nvidia-prime-applet are installed when adding
  nvidia drivers, if they're not already installed.  They get left
  during removals in case the user installs drivers outside of package
  management.

Second commit is a small tweak to the progress bar to center it with other content on its 'row' and allow it to expand.