### PR TITLE
Migrate from aptdaemon to packagekit

### DIFF
--- a/generate_desktop_files
+++ b/generate_desktop_files
@@ -12,7 +12,7 @@ gettext.install(DOMAIN, PATH)
 
 prefix = "[Desktop Entry]\n"
 
-suffix = """Exec=pkexec driver-manager
+suffix = """Exec=driver-manager
 Icon=mintdrivers
 Terminal=false
 X-MultipleArgs=false
@@ -28,7 +28,7 @@ additionalfiles.generate(DOMAIN, PATH, "usr/share/applications/mintdrivers.deskt
 
 prefix = "[Desktop Entry]\n"
 
-suffix = """Exec=pkexec driver-manager
+suffix = """Exec=driver-manager
 Icon=mintdrivers
 Terminal=false
 Type=Application

--- a/test
+++ b/test
@@ -2,4 +2,4 @@
 
 sudo rm -rf /usr/lib/linuxmint/mintDrivers
 sudo cp -R usr /
-sudo mintdrivers
+mintdrivers

--- a/usr/bin/driver-manager
+++ b/usr/bin/driver-manager
@@ -4,8 +4,4 @@ import os
 import subprocess
 import sys
 
-if os.getuid() != 0:
-	print("mintdrivers needs to be run as root.")
-	sys.exit(1)
-
 subprocess.Popen("/usr/lib/linuxmint/mintdrivers/mintdrivers.py")

--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -124,10 +124,7 @@ class Application():
         self.builder.get_object("error_label").set_label(msg)
 
     def on_cache_update_progress(self, progress, ptype, data=None):
-        if ptype == packagekit.ProgressType.PERCENTAGE:
-            prog_value = progress.get_property('percentage')
-            self.builder.get_object("refresh_progressbar").set_fraction(prog_value / 100.0)
-            XApp.set_window_progress(self.window_main, prog_value)
+        pass
 
     def on_cache_update_finished(self, source, result, data=None):
         XApp.set_window_progress(self.window_main, 0)

--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -11,12 +11,10 @@ import gi
 gi.require_version("GdkPixbuf", "2.0")
 gi.require_version("Gtk", "3.0")
 gi.require_version("XApp", "1.0")
-from gi.repository import GdkPixbuf, Gtk, XApp
+gi.require_version("PackageKitGlib", "1.0")
+from gi.repository import GdkPixbuf, Gtk, XApp, Gio
+from gi.repository import PackageKitGlib as packagekit
 from UbuntuDrivers import detect
-from aptdaemon import client
-from aptdaemon.enums import ERROR_UNKNOWN
-from aptdaemon.errors import NotAuthorizedError, TransactionFailed
-from aptdaemon.gtk3widgets import AptErrorDialog, AptProgressDialog
 import re
 import urllib
 
@@ -74,7 +72,6 @@ class Application():
 
         self.needs_restart = False
         self.live_mode = False
-        self.apt_client = client.AptClient()
 
         with open('/proc/cmdline') as f:
             cmdline = f.read()
@@ -90,29 +87,27 @@ class Application():
                 self.update_cache()
 
     def update_cache(self):
-        self.update_transaction = self.apt_client.update_cache()
-        self.update_transaction.connect("finished", self._on_cache_update_finished)
-        dia = AptProgressDialog(self.update_transaction)
-        dia.set_transient_for(self.window_main)
-        dia.set_modal(True)
-        dia.run(close_on_finished=True, show_error=True,
-                reply_handler=lambda: True,
-                error_handler=self.on_error,
-                )
+        task = packagekit.Task()
+        task.refresh_cache_async(True, Gio.Cancellable(), self.on_cache_update_progress, (None, ), self.on_cache_update_finished, (None, ))
 
-    def on_error(self, error):
-        if isinstance(error, NotAuthorizedError):
-                # Silently ignore auth failures
-            return
-        elif not isinstance(error, TransactionFailed):
-            # Catch internal errors of the client
-            error = TransactionFailed(ERROR_UNKNOWN, str(error))
-        dia = AptErrorDialog(error)
-        dia.run()
-        dia.hide()
-        self.apt_cache = apt.Cache()
+    def on_error(summary, msg):
+        """ show a error dialog """
+        dialog = Gtk.MessageDialog(parent=self.window_main,
+                                   flags=Gtk.DialogFlags.MODAL,
+                                   type=Gtk.MessageType.ERROR,
+                                   buttons=Gtk.ButtonsType.OK,
+                                   message_format=None)
+        dialog.set_markup("<big><b>%s</b></big>\n\n%s" % (summary, msg))
+        dialog.run()
+        dialog.destroy()
+        return False
 
-    def _on_cache_update_finished(self, transaction, exit_state):
+    def on_cache_update_progress(self, progress, ptype, data=None):
+        if ptype == packagekit.ProgressType.PERCENTAGE:
+            prog_value = progress.get_property('percentage')
+            #print("cache progress", prog_value)
+
+    def on_cache_update_finished(self, source, result, data=None):
         self.show_drivers()
 
     def quit_application(self, widget=None, event=None):
@@ -190,11 +185,11 @@ class Application():
                 self.update_cache()
             else:
                 self.info_bar.show()
-        except (NotAuthorizedError, TransactionFailed) as e:
+        except Exception as e:
             print("An error occurred: {}".format(e))
             self.info_bar.show()
 
-    def on_driver_changes_progress(self, transaction, progress):
+    def on_driver_changes_progress(self, progress, ptype, data=None):
         #print(progress)
         self.button_driver_revert.set_visible(False)
         self.button_driver_apply.set_visible(False)
@@ -204,108 +199,78 @@ class Application():
         self.progress_bar.set_visible(True)
 
         self.label_driver_action.set_label(_("Applying changes..."))
-        self.progress_bar.set_fraction(progress / 100.0)
-        XApp.set_window_progress(self.window_main, progress)
+        if ptype == packagekit.ProgressType.PERCENTAGE:
+            prog_value = progress.get_property('percentage')
+            self.progress_bar.set_fraction(prog_value / 100.0)
+            XApp.set_window_progress(self.window_main, progress)
 
-    def on_driver_changes_finish(self, transaction, exit_state):
-        self.needs_restart = True
-        self.progress_bar.set_visible(False)
-        self.clear_changes()
-        self.apt_cache = apt.Cache()
-        self.set_driver_action_status()
-        self.update_label_and_icons_from_status()
-        self.button_driver_revert.set_visible(True)
-        self.button_driver_apply.set_visible(True)
-        self.button_driver_cancel.set_visible(False)
-        self.scrolled_window_drivers.set_sensitive(True)
+    def on_driver_changes_finish(self, source, result, installs_pending):
+        results = None
+        try:
+            results = self.pk_task.generic_finish(result)
+        except Exception as e:
+            self.on_driver_changes_revert()
+            self.on_error(_("Error while applying changes"), str(e))
+        if not installs_pending:
+            self.progress_bar.set_visible(False)
+            self.clear_changes()
+            self.apt_cache = apt.Cache()
+            self.set_driver_action_status()
+            self.update_label_and_icons_from_status()
+            self.button_driver_revert.set_visible(True)
+            self.button_driver_apply.set_visible(True)
+            self.button_driver_cancel.set_visible(False)
+            self.scrolled_window_drivers.set_sensitive(True)
         XApp.set_window_progress(self.window_main, 0)
-
-    def on_driver_changes_error(self, transaction, error_code, error_details):
-        self.on_driver_changes_revert()
-        self.set_driver_action_status()
-        self.update_label_and_icons_from_status()
-        self.button_driver_revert.set_visible(True)
-        self.button_driver_apply.set_visible(True)
-        self.button_driver_cancel.set_visible(False)
-        self.scrolled_window_drivers.set_sensitive(True)
-        self.on_error(transaction.error)
-        XApp.set_window_progress(self.window_main, 0)
-
-    def on_driver_changes_cancellable_changed(self, transaction, cancellable):
-        self.button_driver_cancel.set_sensitive(cancellable)
 
     def on_driver_changes_apply(self, button):
-
+        self.pk_task = packagekit.Task()
         installs = []
         removals = []
 
         for pkg in self.driver_changes:
             if pkg.is_installed:
-                removals.append(pkg.shortname)
-
-                if pkg.shortname.startswith("nvidia-driver"):
-                    # most nvidia packages get caught with remove_obsolete_depends,
-                    # but they don't end up purged.  We need to purge every related
-                    # package or else there will be dependency issues if the user
-                    # tries to reinstall a different version, either simultaneously,
-                    # or at a later date.
-                    version = pkg.shortname.rpartition("-")[2]
-                    for pkg_name in self.apt_cache.keys():
-                        if "nvidia" in pkg_name and version in pkg_name:
-                            if self.apt_cache[pkg_name].is_installed:
-                                if pkg_name not in removals:
-                                    print ("Remove %s" % pkg_name)
-                                    removals.append(pkg_name)
-                print ("Remove %s" % pkg.shortname)
+                removals.append(self.get_package_id(pkg.installed))
+                # The main NVIDIA package is only a metapackage.
+                # We need to collect its dependencies, so that
+                # we can uninstall the driver properly.
+                if 'nvidia' in pkg.shortname:
+                    for dep in self.get_dependencies(self.apt_cache, pkg.shortname, 'nvidia'):
+                        dep_pkg = self.apt_cache[dep]
+                        if dep_pkg.is_installed:
+                            removals.append(self.get_package_id(dep_pkg.installed))
             else:
-                installs.append(pkg.shortname)
-                print ("Install %s" % pkg.shortname)
+                installs.append(self.get_package_id(pkg.candidate))
 
-        adding_nvidia = False
-        removing_nvidia = False
-        for pkg_name in installs:
-            if "nvidia" in pkg_name:
-                adding_nvidia = True
-        for pkg_name in removals:
-            if "nvidia" in pkg_name:
-                removing_nvidia = True
-        # If we end up with no nvidia drivers, remove nvidia-settings so it's not in the menu.
-        # nvidia settings is always the latest driver version
-        if removing_nvidia and not adding_nvidia:
-            try:
-                pkg = self.apt_cache["nvidia-settings"]
-                if pkg.is_installed:
-                    print("Removing nvidia-settings")
-                    removals.append("nvidia-settings")
-            except:
-                pass
-        # If we're adding nvidia from not having them, add the nvidia-prime and the prime applet
-        # nvidia-prime-applet is not pulled in by anything, and it may have been removed accidentally
-        # at some point.
-        elif adding_nvidia and not removing_nvidia:
-            for pkg_name in ("nvidia-prime", "nvidia-prime-applet"):
-                try:
-                    pkg = self.apt_cache[pkg_name]
-                    if not pkg.is_installed:
-                        print("Installing %s" % pkg_name)
-                        installs.append(pkg_name)
-                except:
-                    pass
-
+        self.cancellable = Gio.Cancellable()
         try:
-            self.transaction = self.apt_client.commit_packages(install=installs, remove=[],
-                                                               reinstall=[], purge=removals, upgrade=[], downgrade=[])
-            self.transaction.set_allow_unauthenticated(True)
-            self.transaction.connect("progress-changed", self.on_driver_changes_progress)
-            self.transaction.connect("cancellable-changed", self.on_driver_changes_cancellable_changed)
-            self.transaction.connect("finished", self.on_driver_changes_finish)
-            self.transaction.connect("error", self.on_driver_changes_error)
-            self.transaction.run()
+            if removals:
+                installs_pending = False
+                if installs:
+                    installs_pending = True
+                self.pk_task.remove_packages_async(removals,
+                            False,  # allow deps
+                            True,  # autoremove
+                            self.cancellable,  # cancellable
+                            self.on_driver_changes_progress,
+                            (None, ),  # progress data
+                            self.on_driver_changes_finish,  # callback ready
+                            installs_pending  # callback data
+                 )
+            if installs:
+                self.pk_task.install_packages_async(installs,
+                        self.cancellable,  # cancellable
+                        self.on_driver_changes_progress,
+                        (None, ),  # progress data
+                        self.on_driver_changes_finish,  # GAsyncReadyCallback
+                        False  # ready data
+                 )
+
             self.button_driver_revert.set_sensitive(False)
             self.button_driver_apply.set_sensitive(False)
             self.scrolled_window_drivers.set_sensitive(False)
-        except (NotAuthorizedError, TransactionFailed) as e:
-            print("Warning: install transaction not completed successfully: {}".format(e))
+        except Exception as e:
+            print("Warning: install not completed successfully: {}".format(e))
 
     def on_driver_changes_revert(self, button_revert=None):
 
@@ -324,7 +289,7 @@ class Application():
         self.button_driver_apply.set_sensitive(False)
 
     def on_driver_changes_cancel(self, button_cancel):
-        self.transaction.cancel()
+        self.cancellable.cancel()
         self.clear_changes()
 
     def on_driver_restart_clicked(self, button_restart):

--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -320,7 +320,7 @@ class Application():
 
     def on_driver_restart_clicked(self, button_restart):
         self.clean_up_media_cdrom()
-        subprocess.call(['reboot'])
+        subprocess.call(['systemctl', 'reboot'])
 
     def clear_changes(self):
         self.orig_selection = {}

--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -212,6 +212,7 @@ class Application():
             self.on_driver_changes_revert()
             self.on_error(_("Error while applying changes"), str(e))
         if not installs_pending:
+            self.needs_restart = True
             self.progress_bar.set_visible(False)
             self.clear_changes()
             self.apt_cache = apt.Cache()

--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -229,13 +229,15 @@ class Application():
 
     def on_driver_changes_finish(self, source, result, installs_pending):
         results = None
+        errors = False
         try:
             results = self.pk_task.generic_finish(result)
         except Exception as e:
             self.on_driver_changes_revert()
             self.on_error(str(e))
+            errors = True
         if not installs_pending:
-            self.needs_restart = True
+            self.needs_restart = (not errors)
             self.progress_bar.set_visible(False)
             self.clear_changes()
             self.apt_cache = apt.Cache()

--- a/usr/share/linuxmint/mintdrivers/main.ui
+++ b/usr/share/linuxmint/mintdrivers/main.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkWindow" id="window_main">
@@ -9,127 +9,30 @@
     <property name="default_width">640</property>
     <property name="default_height">480</property>
     <property name="icon_name">jockey</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
-      <object class="GtkBox" id="vbox_drivers">
+      <object class="GtkStack" id="stack">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">12</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">6</property>
+        <property name="transition_type">over-left-right</property>
         <child>
-          <object class="GtkScrolledWindow" id="scrolled_window_drivers">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="shadow_type">in</property>
-            <child>
-              <object class="GtkViewport" id="viewport_drivers">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="shadow_type">none</property>
-                <child>
-                  <object class="GtkBox" id="box_driver_detail">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkInfoBar" id="info_bar">
-                        <property name="app_paintable">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="message_type">warning</property>
-                        <child internal-child="action_area">
-                          <object class="GtkButtonBox" id="infobar-action_area">
-                            <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <property name="layout_style">end</property>
-                            <child>
-                              <object class="GtkButton" id="button_info_bar">
-                                <property name="label">gtk-ok</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_stock">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child internal-child="content_area">
-                          <object class="GtkBox" id="infobar-content_area">
-                            <property name="can_focus">False</property>
-                            <property name="spacing">16</property>
-                            <child>
-                              <object class="GtkImage" id="image1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="icon_name">dialog-warning-symbolic</property>
-                                <property name="icon_size">3</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="info_bar_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="label" translatable="yes">label1</property>
-                                <property name="wrap">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="box_driver_action">
+          <object class="GtkBox" id="refresh_page">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="spacing">6</property>
+            <property name="valign">center</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="border_width">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
             <child>
-              <object class="GtkLabel" id="label_driver_action">
+              <object class="GtkSpinner" id="spinner">
+                <property name="height_request">50</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="xalign">0</property>
+                <property name="active">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -138,57 +41,346 @@
               </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Looking for hardware drivers...</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkProgressBar" id="refresh_progressbar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">50</property>
+                <property name="margin_right">50</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="name">refresh_page</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="drivers_page">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolled_window_drivers">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkViewport" id="viewport_drivers">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkBox" id="box_driver_detail">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkInfoBar" id="info_bar">
+                            <property name="app_paintable">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="message_type">warning</property>
+                            <child internal-child="action_area">
+                              <object class="GtkButtonBox">
+                                <property name="can_focus">False</property>
+                                <property name="spacing">6</property>
+                                <property name="layout_style">end</property>
+                                <child>
+                                  <object class="GtkButton" id="button_info_bar">
+                                    <property name="label">gtk-ok</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="use_stock">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child internal-child="content_area">
+                              <object class="GtkBox">
+                                <property name="can_focus">False</property>
+                                <property name="spacing">16</property>
+                                <child>
+                                  <object class="GtkImage" id="image1">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="icon_name">dialog-warning-symbolic</property>
+                                    <property name="icon_size">3</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="info_bar_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">label1</property>
+                                    <property name="wrap">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="box_driver_action">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkLabel" id="label_driver_action">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">drivers_page</property>
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkBox" id="no_drivers_page">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="border_width">12</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="pixel_size">96</property>
+                <property name="icon_name">object-select-symbolic</property>
+                <property name="icon_size">6</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">12</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Your computer does not need any additional drivers</property>
+                <property name="wrap">True</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">no_drivers_page</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="error_page">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="border_width">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="vexpand">False</property>
+                    <property name="pixel_size">96</property>
+                    <property name="icon_name">dialog-warning-symbolic</property>
+                    <property name="icon_size">6</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">12</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="vexpand">False</property>
+                    <property name="label" translatable="yes">An error occurred</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="error_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">start</property>
+                <property name="margin_top">10</property>
+                <property name="vexpand">True</property>
+                <property name="wrap">True</property>
+                <property name="selectable">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="vexpand">False</property>
+                <property name="layout_style">center</property>
+                <child>
+                  <object class="GtkButton" id="error_button">
+                    <property name="label" translatable="yes">OK</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">error_page</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
-  </object>
-   <object class="GtkBox" id="no_drivers">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="valign">center</property>
-    <property name="hexpand">True</property>
-    <property name="vexpand">True</property>
-    <property name="orientation">vertical</property>
-    <child>
-      <object class="GtkImage" id="no_drivers_status">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="pixel_size">96</property>
-        <property name="icon_name">object-select-symbolic</property>
-        <property name="icon_size">6</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="padding">12</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label_no_drivers">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Your computer does not need any additional drivers</property>
-        <attributes>
-          <attribute name="weight" value="bold"/>
-        </attributes>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/usr/share/linuxmint/mintdrivers/main.ui
+++ b/usr/share/linuxmint/mintdrivers/main.ui
@@ -17,73 +17,45 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="transition_duration">100</property>
-        <property name="transition_type">crossfade</property>
+        <property name="transition_type">slide-left-right</property>
         <child>
           <object class="GtkBox" id="refresh_page">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="valign">center</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <property name="border_width">12</property>
             <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
             <child>
-              <object class="GtkProgressBar" id="refresh_progressbar">
+              <object class="GtkSpinner" id="spinner">
+                <property name="height_request">50</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">50</property>
-                <property name="margin_right">50</property>
-                <property name="margin_bottom">10</property>
+                <property name="active">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack_type">end</property>
-                <property name="position">2</property>
+                <property name="fill">True</property>
+                <property name="padding">12</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox">
+              <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="valign">center</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">10</property>
-                <child>
-                  <object class="GtkSpinner" id="spinner">
-                    <property name="height_request">50</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="active">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="valign">start</property>
-                    <property name="label" translatable="yes">Looking for hardware drivers...</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="12500"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
+                <property name="label" translatable="yes">Looking for hardware drivers...</property>
+                <property name="wrap">True</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                  <attribute name="size" value="11000"/>
+                </attributes>
               </object>
               <packing>
-                <property name="expand">True</property>
+                <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
@@ -270,23 +242,24 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="padding">12</property>
-                <property name="position">1</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Your computer does not need any additional drivers</property>
+                <property name="label" translatable="yes">Your computer does not need any additional drivers.</property>
                 <property name="wrap">True</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
+                  <attribute name="size" value="11000"/>
                 </attributes>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/usr/share/linuxmint/mintdrivers/main.ui
+++ b/usr/share/linuxmint/mintdrivers/main.ui
@@ -16,7 +16,7 @@
       <object class="GtkStack" id="stack">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="transition_type">over-left-right</property>
+        <property name="transition_type">crossfade</property>
         <child>
           <object class="GtkBox" id="refresh_page">
             <property name="visible">True</property>

--- a/usr/share/linuxmint/mintdrivers/main.ui
+++ b/usr/share/linuxmint/mintdrivers/main.ui
@@ -16,56 +16,74 @@
       <object class="GtkStack" id="stack">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="transition_duration">100</property>
         <property name="transition_type">crossfade</property>
         <child>
           <object class="GtkBox" id="refresh_page">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="valign">center</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <property name="border_width">12</property>
             <property name="orientation">vertical</property>
             <property name="spacing">12</property>
             <child>
-              <object class="GtkSpinner" id="spinner">
-                <property name="height_request">50</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="active">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Looking for hardware drivers...</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkProgressBar" id="refresh_progressbar">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">50</property>
                 <property name="margin_right">50</property>
+                <property name="margin_bottom">10</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkSpinner" id="spinner">
+                    <property name="height_request">50</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="active">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">start</property>
+                    <property name="label" translatable="yes">Looking for hardware drivers...</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="12500"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>

--- a/usr/share/linuxmint/mintdrivers/main.ui
+++ b/usr/share/linuxmint/mintdrivers/main.ui
@@ -206,6 +206,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
+                    <property name="wrap">True</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>


### PR DESCRIPTION
The first thing we were trying to solve was the inability to install nvidia 450 drivers on some computers running Mint 19.3.

Because APT recommends are disabled, mintdrivers list the recommended packages and adds them to the list of packages to install. This failed with the newly introduced nvidia 450 package because of the complexity of some of its dependencies. The aptdaemon resolver was unable to solve the request.

Removing the code which explicitly adds the recommended packages solved the issue, so it was decided to enable APT recommends via an update in mintsystem and remove that code here in mintdrivers.

Then, we found another issue. Aptdaemon does NOT, EVER, install recommended packages, whether these are enabled in the APT configuration or not. We worked around this issue in Mint thinking it was simply caused by the fact that these were disabled in Mint... we had no idea this affected all other distributions.

Rather than trying to patch aptdaemon we looked at alternatives. One of them was to switch to packagekit and this is what this PR is doing.

Other than fixing the issue, switching to packagekit also means we can run mintdrivers in user mode, and thus no longer ask for a password at launch.

One final note: to be able to backport mintdrivers to past releases, mintdrivers now handles its own translations.
