### PR TITLE
remove unused assignment to real_code

### DIFF
--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -130,9 +130,8 @@ class Application:
         # This will bring the ui back to pre-apply state. Returning True will reset
         # entirely.
 
-        # it thinks it's a PkClientError but it's really PkErrorEnum
+        # it thinks it's a PkClientError, but it's really PkErrorEnum
         # the GError code is set to 0xFF + code
-        real_code = error.code
         if error.code >= 0xFF:
             real_code = error.code - 0xFF
 


### PR DESCRIPTION
The variable `real_code` is only used and reassigned in the if statement. So I removed the outer  declaration. I also added an missing comma to the documentation.