### PR TITLE
remove unused variable results

### DIFF
--- a/usr/lib/linuxmint/mintdrivers/mintdrivers.py
+++ b/usr/lib/linuxmint/mintdrivers/mintdrivers.py
@@ -240,10 +240,9 @@ class Application:
             XApp.set_window_progress(self.window_main, prog_value)
 
     def on_driver_changes_finish(self, source, result, installs):
-        results = None
         errors = False
         try:
-            results = self.pk_task.generic_finish(result)
+            self.pk_task.generic_finish(result)
         except GLib.Error as e:
             errors = True
             if self.on_error(e):


### PR DESCRIPTION
The variable `results` is never used. So I removed it's declaration and it's reassignment.